### PR TITLE
Fix error in headerbar example

### DIFF
--- a/examples/layout_headerbar_example.py
+++ b/examples/layout_headerbar_example.py
@@ -8,7 +8,7 @@ class HeaderBarWindow(Gtk.Window):
         self.set_default_size(400, 200)
 
         hb = Gtk.HeaderBar()
-        hb.props.set_show_close_button(True)
+        hb.set_show_close_button(True)
         hb.props.title = "HeaderBar example"
         self.set_titlebar(hb)
 


### PR DESCRIPTION
Fixes

```
AttributeError: 'gi._gobject.GProps' object has no attribute 'set_show_close_button'
```
