### PR TITLE
Typo in drag and drop section

### DIFF
--- a/source/drag_and_drop.txt
+++ b/source/drag_and_drop.txt
@@ -55,7 +55,7 @@ Drag Source Signals
 +--------------------+--------------------------------------------------------------+----------------------------------------------------+
 | drag-data-delete   | When a drag with the action Gdk.DragAction.MOVE is completed | Delete data from the source to complete the 'move' |
 +--------------------+--------------------------------------------------------------+----------------------------------------------------+
-| drag-data-end      | When the drag is complete                                    | Undo anything done in drag-begin                   |
+| drag-end           | When the drag is complete                                    | Undo anything done in drag-begin                   |
 +--------------------+--------------------------------------------------------------+----------------------------------------------------+
 
 Drag Destination Signals


### PR DESCRIPTION
The table currently reads `drag-data-end`, but I think it should be just `drag-end`.

Source: http://lazka.github.io/pgi-docs/#Gtk-3.0/classes/Widget.html#Gtk.Widget.signals.drag_end

