### PR TITLE
Use destroy signal instead of delete-event

### DIFF
--- a/examples/builder_example.glade
+++ b/examples/builder_example.glade
@@ -3,7 +3,7 @@
   <!-- interface-requires gtk+ 3.0 -->
   <object class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
-    <signal name="delete-event" handler="onDeleteWindow" swapped="no"/>
+    <signal name="destroy" handler="onDestroy" swapped="no"/>
     <child>
       <object class="GtkButton" id="button1">
         <property name="label" translatable="yes">button</property>

--- a/examples/builder_example.py
+++ b/examples/builder_example.py
@@ -3,8 +3,8 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 class Handler:
-    def onDeleteWindow(self, *args):
-        Gtk.main_quit(*args)
+    def onDestroy(self, *args):
+        Gtk.main_quit()
 
     def onButtonPressed(self, button):
         print("Hello World!")

--- a/examples/button_example.py
+++ b/examples/button_example.py
@@ -34,6 +34,6 @@ class ButtonWindow(Gtk.Window):
         Gtk.main_quit()
 
 win = ButtonWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/cellrendereraccel_example.py
+++ b/examples/cellrendereraccel_example.py
@@ -41,6 +41,6 @@ class CellRendererAccelWindow(Gtk.Window):
         self.liststore[path][1] = None
 
 win = CellRendererAccelWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/cellrenderercombo_example.py
+++ b/examples/cellrenderercombo_example.py
@@ -42,6 +42,6 @@ class CellRendererComboWindow(Gtk.Window):
         self.liststore_hardware[path][1] = text
 
 win = CellRendererComboWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/cellrendererpixbuf_example.py
+++ b/examples/cellrendererpixbuf_example.py
@@ -28,6 +28,6 @@ class CellRendererPixbufWindow(Gtk.Window):
         self.add(treeview)
 
 win = CellRendererPixbufWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/cellrendererprogress_example.py
+++ b/examples/cellrendererprogress_example.py
@@ -55,6 +55,6 @@ class CellRendererProgressWindow(Gtk.Window):
         self.current_iter = self.liststore.get_iter_first()
 
 win = CellRendererProgressWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/cellrendererspin_example.py
+++ b/examples/cellrendererspin_example.py
@@ -36,6 +36,6 @@ class CellRendererSpinWindow(Gtk.Window):
         self.liststore[path][1] = int(value)
 
 win = CellRendererSpinWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/cellrenderertext_example.py
+++ b/examples/cellrenderertext_example.py
@@ -35,6 +35,6 @@ class CellRendererTextWindow(Gtk.Window):
         self.liststore[path][1] = text
 
 win = CellRendererTextWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/cellrenderertoggle_example.py
+++ b/examples/cellrenderertoggle_example.py
@@ -44,6 +44,6 @@ class CellRendererToggleWindow(Gtk.Window):
             row[2] = (row.path == selected_path)
 
 win = CellRendererToggleWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/checkbutton_example.py
+++ b/examples/checkbutton_example.py
@@ -28,6 +28,6 @@ class CheckButtonWindow(Gtk.Window):
         print("Button", name, "was turned", state)
 
 win = CheckButtonWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/clipboard_example.py
+++ b/examples/clipboard_example.py
@@ -55,6 +55,6 @@ class ClipboardWindow(Gtk.Window):
 
 
 win = ClipboardWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/combobox_example.py
+++ b/examples/combobox_example.py
@@ -73,6 +73,6 @@ class ComboBoxWindow(Gtk.Window):
             print("Selected: currency=%s" % text)
 
 win = ComboBoxWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/dialog_example.py
+++ b/examples/dialog_example.py
@@ -41,6 +41,6 @@ class DialogWindow(Gtk.Window):
         dialog.destroy()
 
 win = DialogWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/drag_and_drop_example.py
+++ b/examples/drag_and_drop_example.py
@@ -108,6 +108,6 @@ class DropArea(Gtk.Label):
                 height))
 
 win = DragDropWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/entry_example.py
+++ b/examples/entry_example.py
@@ -72,6 +72,6 @@ class EntryWindow(Gtk.Window):
             icon_name)
 
 win = EntryWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/extended_example.py
+++ b/examples/extended_example.py
@@ -15,6 +15,6 @@ class MyWindow(Gtk.Window):
         print("Hello World")
 
 win = MyWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/filechooserdialog_example.py
+++ b/examples/filechooserdialog_example.py
@@ -68,6 +68,6 @@ class FileChooserWindow(Gtk.Window):
         dialog.destroy()
 
 win = FileChooserWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/iconview_example.py
+++ b/examples/iconview_example.py
@@ -24,6 +24,6 @@ class IconViewWindow(Gtk.Window):
     self.add(iconview)
 
 win = IconViewWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/label_example.py
+++ b/examples/label_example.py
@@ -74,6 +74,6 @@ class LabelWindow(Gtk.Window):
         self.add(hbox)
 
 window = LabelWindow()        
-window.connect("delete-event", Gtk.main_quit)
+window.connect("destroy", Gtk.main_quit)
 window.show_all()
 Gtk.main()

--- a/examples/layout_box_example.py
+++ b/examples/layout_box_example.py
@@ -25,6 +25,6 @@ class MyWindow(Gtk.Window):
         print("Goodbye")
 
 win = MyWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/layout_flowbox_example.py
+++ b/examples/layout_flowbox_example.py
@@ -115,6 +115,6 @@ class FlowBoxWindow(Gtk.Window):
 
 
 win = FlowBoxWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/layout_grid_example.py
+++ b/examples/layout_grid_example.py
@@ -25,6 +25,6 @@ class GridWindow(Gtk.Window):
         grid.attach_next_to(button6, button5, Gtk.PositionType.RIGHT, 1, 1)
 
 win = GridWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/layout_headerbar_example.py
+++ b/examples/layout_headerbar_example.py
@@ -36,6 +36,6 @@ class HeaderBarWindow(Gtk.Window):
         self.add(Gtk.TextView())
 
 win = HeaderBarWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/layout_listbox_example.py
+++ b/examples/layout_listbox_example.py
@@ -81,6 +81,6 @@ class ListBoxWindow(Gtk.Window):
         listbox_2.show_all()
 
 win = ListBoxWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/layout_stack_example.py
+++ b/examples/layout_stack_example.py
@@ -28,6 +28,6 @@ class StackWindow(Gtk.Window):
         vbox.pack_start(stack, True, True, 0)
 
 win = StackWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/layout_table_example.py
+++ b/examples/layout_table_example.py
@@ -25,6 +25,6 @@ class TableWindow(Gtk.Window):
         table.attach(button6, 2, 3, 2, 3)
 
 win = TableWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/linkbutton_example.py
+++ b/examples/linkbutton_example.py
@@ -12,6 +12,6 @@ class LinkButtonWindow(Gtk.Window):
         self.add(button)
 
 win = LinkButtonWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/menu_example.py
+++ b/examples/menu_example.py
@@ -156,6 +156,6 @@ class MenuExampleWindow(Gtk.Window):
             return True # event has been handled
 
 window = MenuExampleWindow()        
-window.connect("delete-event", Gtk.main_quit)
+window.connect("destroy", Gtk.main_quit)
 window.show_all()
 Gtk.main()

--- a/examples/messagedialog_example.py
+++ b/examples/messagedialog_example.py
@@ -73,6 +73,6 @@ class MessageDialogWindow(Gtk.Window):
         dialog.destroy()
 
 win = MessageDialogWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/notebook_plain_example.py
+++ b/examples/notebook_plain_example.py
@@ -28,6 +28,6 @@ class MyWindow(Gtk.Window):
         )
 
 win = MyWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/progressbar_example.py
+++ b/examples/progressbar_example.py
@@ -68,6 +68,6 @@ class ProgressBarWindow(Gtk.Window):
         return True
 
 win = ProgressBarWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/radiobutton_example.py
+++ b/examples/radiobutton_example.py
@@ -33,6 +33,6 @@ class RadioButtonWindow(Gtk.Window):
         print("Button", name, "was turned", state)
 
 win = RadioButtonWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -3,6 +3,6 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 win = Gtk.Window()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/spinbutton_example.py
+++ b/examples/spinbutton_example.py
@@ -35,6 +35,6 @@ class SpinButtonWindow(Gtk.Window):
         self.spinbutton.set_update_policy(policy)
 
 win = SpinButtonWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/spinner_example.py
+++ b/examples/spinner_example.py
@@ -8,7 +8,7 @@ class SpinnerAnimation(Gtk.Window):
 
         Gtk.Window.__init__(self, title="Spinner")
         self.set_border_width(3)
-        self.connect("delete-event", Gtk.main_quit)
+        self.connect("destroy", Gtk.main_quit)
 
         self.button = Gtk.ToggleButton("Start Spinning")
         self.button.connect("toggled", self.on_button_toggled)

--- a/examples/switch_example.py
+++ b/examples/switch_example.py
@@ -29,7 +29,7 @@ class SwitcherWindow(Gtk.Window):
         print("Switch was turned", state)
 
 win = SwitcherWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()
 

--- a/examples/textview_example.py
+++ b/examples/textview_example.py
@@ -198,6 +198,6 @@ class TextViewWindow(Gtk.Window):
             self.search_and_mark(text, match_end)
 
 win = TextViewWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/togglebutton_example.py
+++ b/examples/togglebutton_example.py
@@ -28,6 +28,6 @@ class ToggleButtonWindow(Gtk.Window):
         print("Button", name, "was turned", state)
 
 win = ToggleButtonWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/examples/treeview_filter_example.py
+++ b/examples/treeview_filter_example.py
@@ -80,6 +80,6 @@ class TreeViewFilterWindow(Gtk.Window):
 
 
 win = TreeViewFilterWindow()
-win.connect("delete-event", Gtk.main_quit)
+win.connect("destroy", Gtk.main_quit)
 win.show_all()
 Gtk.main()

--- a/source/basics.txt
+++ b/source/basics.txt
@@ -61,15 +61,15 @@ disconnect a  specific callback using the function :func:`disconnect_by_func`:
 
     widget.disconnect_by_func(callback)
 
-Almost all applications will connect to the "delete-event" signal of the
-top-level window. It is emitted if a user requests that a toplevel window is
-closed. The default handler for this signal destroys the window, but does
-not terminate the application. Connecting the "delete-event" signal
+Applications should connect to the "destroy" signal of the top-level window.
+It is emitted an object is destroyed, so when a user requests that a toplevel
+window is closed, the default handler for this signal destroys the window, but does
+not terminate the application. Connecting the "destroy" signal of the top-level window
 to the function :func:`Gtk.main_quit` will result in the desired behaviour.
 
 .. code-block:: python
 
-    window.connect("delete-event", Gtk.main_quit)
+    window.connect("destroy", Gtk.main_quit)
 
 Calling :func:`Gtk.main_quit` makes the main loop inside of :func:`Gtk.main` return.
 

--- a/source/builder.txt
+++ b/source/builder.txt
@@ -82,14 +82,14 @@ Connecting Signals
 ------------------
 Glade also makes it possible to define signals which you can connect to handlers in your code without extracting every object from the builder and connecting to the signals manually.
 The first thing to do is to declare the signal names in Glade.
-For this example we will act when the window should be closed and when the button was pressed, so we give the name "onDeleteWindow" to the "delete-event" signal of the window and "onButtonPressed" to the "pressed" signal of the button.
+For this example we will act when the window is closed and when the button was pressed, so we give the name "onDestroy" to the callback handling the "destroy" signal of the window and "onButtonPressed" to the callback handling the "pressed" signal of the button.
 Now the XML file should look like this.
 
 .. literalinclude:: ../examples/builder_example.glade
 	:language: xml
 
 Now we have to define the handler functions in our code.
-The *onDeleteWindow* should simply result in a call to :meth:`Gtk.main_quit`.
+The *onDestroy* should simply result in a call to :meth:`Gtk.main_quit`.
 When the button is pressed we would like to print the string "Hello World!", so we define the handler as follows
 
 .. code-block:: python
@@ -103,7 +103,7 @@ The easiest way to do this is to define a *dict* with a mapping from the names t
 .. code-block:: python
 
     handlers = {
-        "onDeleteWindow": Gtk.main_quit,
+        "onDestroy": Gtk.main_quit,
         "onButtonPressed": hello
     }
     builder.connect_signals(handlers)


### PR DESCRIPTION
The `delete-event` is used to react on the user trying to close the window, for example to show a save popup. The real signal called when the window is destroyed, is, well, `destroy`.

Furthermore, the signature of these events are different, and `delete-event` doesn't mix well with `gtk_main_quit`, as `delete-event` returns a boolean and `gtk_main_quit` returns a void. `destroy` returns void so it doesn't have this problem.