### PR TITLE
popover_example: set size, remove not used method

### DIFF
--- a/examples/popover_example.py
+++ b/examples/popover_example.py
@@ -8,6 +8,7 @@ class PopoverWindow(Gtk.Window):
     def __init__(self):
         Gtk.Window.__init__(self, title="Popover Demo")
         self.set_border_width(10)
+        self.set_default_size(300, 200)
 
         outerbox = Gtk.Box(spacing=6, orientation=Gtk.Orientation.VERTICAL)
         self.add(outerbox)
@@ -27,9 +28,6 @@ class PopoverWindow(Gtk.Window):
         self.popover.set_relative_to(button)
         self.popover.show_all()
         self.popover.popup()
-
-    def on_open_clicked(self, button):
-        print('"Open" button was clicked')
 
 
 win = PopoverWindow()


### PR DESCRIPTION
Current example is open as a window with button-only, without any space
for a popup, so the popup is not visible when opened. 

A method `on_open_clicked` was not a part of this example.