### PR TITLE
Correct expected type description

### DIFF
--- a/source/objects.txt
+++ b/source/objects.txt
@@ -82,8 +82,8 @@ The second part, ``None``, indicates the return type of the signal,
 usually ``None``.
 
 ``(int,)`` indicates the signal arguments, here, the signal will only
-take one argument, whose type is int. This argument type must be a sequence,
-so here as a tuple with one element must end with a comma.
+take one argument, whose type is int. Types of arguments required by 
+signal are declared as a sequence, here is one-element tuple.
 
 Signals can be emitted using :meth:`GObject.GObject.emit`:
 

--- a/source/objects.txt
+++ b/source/objects.txt
@@ -336,8 +336,8 @@ API
 
         :const:`GObject.SIGNAL_RUN_FIRST` can be replaced with
         :const:`GObject.SIGNAL_RUN_LAST` or :const:`GObject.SIGNAL_RUN_CLEANUP`.
-        ``None`` is the return type of the signal. ``(int,)`` is the list of the
-        parameters of the signal, it must end with a comma.
+        ``None`` is the return type of the signal. ``(int,)`` is the tuple of the
+        parameters of the signal.
 
     .. attribute:: __gproperties__
 

--- a/source/objects.txt
+++ b/source/objects.txt
@@ -82,8 +82,8 @@ The second part, ``None``, indicates the return type of the signal,
 usually ``None``.
 
 ``(int,)`` indicates the signal arguments, here, the signal will only
-take one argument, whose type is int. This argument type list must end with a
-comma.
+take one argument, whose type is int. This argument type must be a sequence,
+so here as a tuple with one element must end with a comma.
 
 Signals can be emitted using :meth:`GObject.GObject.emit`:
 


### PR DESCRIPTION
Expected type is any sequence. Example presents one-element
tuple and this is only reason why it has comma at the end.

See: https://gitlab.gnome.org/GNOME/pygobject/-/blob/master/gi/gimodule.c#L763 