### PR TITLE
Update SpinButton Example to Print Value

### DIFF
--- a/examples/spinbutton_example.py
+++ b/examples/spinbutton_example.py
@@ -15,6 +15,7 @@ class SpinButtonWindow(Gtk.Window):
         adjustment = Gtk.Adjustment(upper=100, step_increment=1, page_increment=10)
         self.spinbutton = Gtk.SpinButton()
         self.spinbutton.set_adjustment(adjustment)
+        self.spinbutton.connect("value-changed", self.on_value_changed)
         hbox.pack_start(self.spinbutton, False, False, 0)
 
         check_numeric = Gtk.CheckButton(label="Numeric")
@@ -24,6 +25,9 @@ class SpinButtonWindow(Gtk.Window):
         check_ifvalid = Gtk.CheckButton(label="If Valid")
         check_ifvalid.connect("toggled", self.on_ifvalid_toggled)
         hbox.pack_start(check_ifvalid, False, False, 0)
+
+    def on_value_changed(self, scroll):
+        print(self.spinbutton.get_value_as_int())
 
     def on_numeric_toggled(self, button):
         self.spinbutton.set_numeric(button.get_active())


### PR DESCRIPTION
Currently the spin button example doesn't have a callback to do anything if the value changes. This change adds a callback and prints the value to the terminal to expand the example.