### PR TITLE
Improve documentation of Gtk.TreeStore()

### DIFF
--- a/examples/treeview_filter_example.py
+++ b/examples/treeview_filter_example.py
@@ -42,7 +42,7 @@ class TreeViewFilterWindow(Gtk.Window):
         self.language_filter.set_visible_func(self.language_filter_func)
 
         # creating the treeview, making it use the filter as a model, and adding the columns
-        self.treeview = Gtk.TreeView.new_with_model(self.language_filter)
+        self.treeview = Gtk.TreeView(model=self.language_filter)
         for i, column_title in enumerate(
             ["Software", "Release Year", "Programming Language"]
         ):

--- a/source/treeview.txt
+++ b/source/treeview.txt
@@ -310,11 +310,13 @@ You can create a new instance of a :class:`Gtk.TreeModelFilter` and give it a mo
 
     filter = model.filter_new()
 
-In the same way the sorting function works, the :class:`Gtk.TreeModelFilter` needs a "visibility" function, which, given a row from the underlying model, will return a boolean indicating if this row should be filtered out or not. It's set by :meth:`Gtk.TreeModelFilter.set_visible_func`:
+In the same way the sorting function works, the :class:`Gtk.TreeModelFilter` uses a "visibility" function, which, given a row from the underlying model, will return a boolean indicating if this row should be filtered out or not. It's set by :meth:`Gtk.TreeModelFilter.set_visible_func`:
 
 .. code-block:: python
 
     filter.set_visible_func(filter_func, data=None)
+
+The alternative to a "visibility" function is to use a boolean column in the model to specify which rows to filter. Choose which column with :meth:`Gtk.TreeModelFilter.set_visible_column`.
 
 Let's look at a full example which uses the whole :class:`Gtk.ListStore` - :class:`Gtk.TreeModelFilter` - :class:`Gtk.TreeModelFilter` - :class:`Gtk.TreeView` stack.
 

--- a/source/treeview.txt
+++ b/source/treeview.txt
@@ -46,10 +46,20 @@ column.
 Adding data to the model is done using :meth:`Gtk.ListStore.append` or
 :meth:`Gtk.TreeStore.append`, depending upon which sort of model was created.
 
+For a list store:
+
 .. code-block:: python
 
     treeiter = store.append(["The Art of Computer Programming",
                              "Donald E. Knuth", 25.46])
+
+For a tree store you must specify an existing row to append the new row to,
+using a :class:`Gtk.TreeIter`, or None for the top level of the tree:
+
+.. code-block:: python
+
+    treeiter = store.append(None, ["The Art of Computer Programming",
+                                   "Donald E. Knuth", 25.46])
 
 Both methods return a :class:`Gtk.TreeIter` instance, which points to the location
 of the newly inserted row. You can retrieve a :class:`Gtk.TreeIter` by calling
@@ -87,21 +97,14 @@ Iterating over all rows of a tree model is very simple as well.
 
 Keep in mind, that if you use :class:`Gtk.TreeStore`, the above code will only
 iterate over the rows of the top level, but not the children of the nodes.
-To iterate over all rows and its children, use the ``print_tree_store`` function.
+To iterate over all rows, use :meth:`Gtk.TreeModel.foreach`.
 
 .. code-block:: python
 
-    def print_tree_store(store):
-        rootiter = store.get_iter_first()
-        print_rows(store, rootiter, "")
+    def print_row(store, treepath, treeiter):
+        print("\t" * (treepath.get_depth() - 1), store[treeiter][:], sep="")
 
-    def print_rows(store, treeiter, indent):
-        while treeiter is not None:
-            print(indent + str(store[treeiter][:]))
-            if store.iter_has_child(treeiter):
-                childiter = store.iter_children(treeiter)
-                print_rows(store, childiter, indent + "\t")
-            treeiter = store.iter_next(treeiter)
+    store.foreach(print_row)
 
 Apart from accessing values stored in a :class:`Gtk.TreeModel` with the list-like
 method mentioned above, it is also possible to

--- a/source/treeview.txt
+++ b/source/treeview.txt
@@ -46,14 +46,14 @@ column.
 Adding data to the model is done using :meth:`Gtk.ListStore.append` or
 :meth:`Gtk.TreeStore.append`, depending upon which sort of model was created.
 
-For a list store:
+For a :class:`Gtk.ListStore`:
 
 .. code-block:: python
 
     treeiter = store.append(["The Art of Computer Programming",
                              "Donald E. Knuth", 25.46])
 
-For a tree store you must specify an existing row to append the new row to,
+For a :class:`Gtk.TreeStore` you must specify an existing row to append the new row to,
 using a :class:`Gtk.TreeIter`, or None for the top level of the tree:
 
 .. code-block:: python

--- a/source/treeview.txt
+++ b/source/treeview.txt
@@ -148,7 +148,7 @@ passing it to the :class:`Gtk.TreeView` constructor, or by calling
 
 .. code-block:: python
 
-    tree = Gtk.TreeView(store)
+    tree = Gtk.TreeView(model=store)
 
 Once the :class:`Gtk.TreeView` widget has a model, it will need to know how to
 display the model. It does this with columns and cell renderers.
@@ -238,7 +238,7 @@ First we need a simple :class:`Gtk.TreeView` and a :class:`Gtk.ListStore` as a m
     model.append(["david"])
     model.append(["benjamin"])
 
-    treeView = Gtk.TreeView(model)
+    treeView = Gtk.TreeView(model=model)
 
     cellRenderer = Gtk.CellRendererText()
     column = Gtk.TreeViewColumn("Title", renderer, text=0)


### PR DESCRIPTION
- Add a snippet with text for Gtk.TreeStore.append()
- Use Gtk.TreeModel.foreach() instead of custom Python code

---

Use keyword arguments with Gtk.Treeview() constructor

Positional arguments are deprecated and be consistent.
