### PR TITLE
Fix tox building

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
     make split-po
     sphinx-build -E -W -b html ../source ../build/html/en
     bash -c "grep -v '^\#' ./LINGUAS | tr '\n' ';' > .tmp-LINGUAS"
-    xargs -a .tmp-LINGUAS -I '{}' -d';' sphinx-build -D language='{}' -E -W -b html ../source '../build/html/{}'
+    xargs -a .tmp-LINGUAS -I '{:}' -d';' sphinx-build -D language='{:}' -E -W -b html ../source '../build/html/{:}'
     rm -f .tmp-LINGUAS
 whitelist_externals =
     /bin/bash


### PR DESCRIPTION
When trying to run tox in the PyGObject-tutorial folder I run into failures.

Looking at https://github.com/tox-dev/tox/issues/1711 , it seems like new tox doesn't like {} , and wants {:} instead. Adding the colon in tox.ini fixes the build for me.