### PR TITLE
Various string fixes

### DIFF
--- a/source/basics.txt
+++ b/source/basics.txt
@@ -55,7 +55,7 @@ has been connected to.
 
 If you have lost the "handler_id" for some reason (for example the handlers 
 were installed using :func:`Gtk.Builder.connect_signals`), you can still 
-disconnect a  specific callback using the function :func:`disconnect_by_func`:
+disconnect a specific callback using the function :func:`disconnect_by_func`:
 
 .. code-block:: python
 

--- a/source/button_widgets.txt
+++ b/source/button_widgets.txt
@@ -111,8 +111,8 @@ The main properties of a :class:`Gtk.SpinButton` are set through
 
 To change the value that :class:`Gtk.SpinButton` is showing, use
 :meth:`Gtk.SpinButton.set_value`. The value entered can either be an integer or
-float, depending on your requirements, use :meth:`Gtk.SpinButton.get_value` or
-:meth:`Gtk.SpinButton.get_value_as_int`, respectively.
+float, depending on your requirements, use :meth:`Gtk.SpinButton.get_value_as_int` or
+:meth:`Gtk.SpinButton.get_value`, respectively.
 
 When you allow the displaying of float values in the spin button, you may wish
 to adjust the number of decimal spaces displayed by calling

--- a/source/dialogs.txt
+++ b/source/dialogs.txt
@@ -53,7 +53,7 @@ MessageDialog
 -------------
 
 :class:`Gtk.MessageDialog` is a convenience class, used to create simple,
-standard message dialogs, with a message, an icon, and buttons for user response
+standard message dialogs, with a message, an icon, and buttons for user response.
 You can specify the type of message and the text in the :class:`Gtk.MessageDialog`
 constructor, as well as specifying standard buttons.
 

--- a/source/layout-table.txt
+++ b/source/layout-table.txt
@@ -20,7 +20,7 @@ You can also set a consistent spacing for all rows and/or columns with
 Note that with these calls, the last row and last column do not get any spacing.
 
 .. deprecated:: 3.4
-   It is reccomened that you use the :class:`Gtk.Grid` for new code.
+   It is recommended that you use the :class:`Gtk.Grid` for new code.
 
 Example
 ^^^^^^^

--- a/source/layout.txt
+++ b/source/layout.txt
@@ -111,7 +111,7 @@ mouse navigation and selection like a typical list.
 
 Using :class:`Gtk.ListBox` is often an alternative to :class:`Gtk.TreeView`, especially
 when the list content has a more complicated layout than what is allowed by a
-:class:`Gtk.CellRenderer`, or when the content is interactive (i.e. has a button
+:class:`Gtk.CellRenderer`, or when the content is interactive (e.g. has a button
 in it).
 
 Although a :class:`Gtk.ListBox` must have only :class:`Gtk.ListBoxRow` children, you can
@@ -224,7 +224,7 @@ The :class:`Gtk.Notebook` widget is a :class:`Gtk.Container` whose children are 
 There are many configuration options for GtkNotebook. Among other things, you
 can choose on which edge the tabs appear (see :meth:`Gtk.Notebook.set_tab_pos`),
 whether, if there are too many tabs to fit the notebook should be made bigger or
-scrolling arrows added (see :meth:`Gtk.Notebook.set_scrollable`, and whether
+scrolling arrows added (see :meth:`Gtk.Notebook.set_scrollable`), and whether
 there will be a popup menu allowing the users to switch pages (see
 :meth:`Gtk.Notebook.popup_enable`, :meth:`Gtk.Notebook.popup_disable`).
 

--- a/source/menus.txt
+++ b/source/menus.txt
@@ -38,7 +38,7 @@ Different classes representing different types of actions exist:
 * :class:`Gtk.RecentAction`: An action of which represents a list of recently
   used files
 
-Actions represent operations that the user can be perform, along with some
+Actions represent operations that the user can perform, along with some
 information how it should be presented in the interface, including its name
 (not for display), its label (for display), an accelerator, whether a label
 indicates a tooltip as well as the callback that is called when the action

--- a/source/objects.txt
+++ b/source/objects.txt
@@ -285,7 +285,7 @@ API
         emitted when any property is changed) until the :meth:`thaw_notify` method is
         called.
 
-        It recommended to use the *with* statement when calling :meth:`freeze_notify`,
+        It is recommended to use the *with* statement when calling :meth:`freeze_notify`,
         that way it is ensured that :meth:`thaw_notify` is called implicitly at
         the end of the block::
 
@@ -295,7 +295,7 @@ API
 
     .. method:: thaw_notify()
 
-        Thaw all the "notify::" signals which were thawed by :meth:`freeze_notify`.
+        Thaw all the "notify::" signals which were frozen by :meth:`freeze_notify`.
 
         It is recommended to not call :meth:`thaw_notify` explicitly but use
         :meth:`freeze_notify` together with the *with* statement.
@@ -344,7 +344,7 @@ API
         .. based on http://www.pygtk.org/articles/subclassing-gobject/sub-classing-gobject-in-python.htm
 
         The :attr:`__gproperties__` dictionary is a class property where you define the
-        properties of your object. This is not the recommend way to define new
+        properties of your object. This is not the recommended way to define new
         properties, the method written above is much less verbose. The benefits
         of this method is that a property can be defined with more settings,
         like the minimum or the maximum for numbers.

--- a/source/treeview.txt
+++ b/source/treeview.txt
@@ -293,7 +293,7 @@ The case-sensitive sorted list will look like::
     david
 
 First of all a comparison function is needed.
-This function gets two rows and has to return a negative integer if the first one should come before the second one, zero if they are equal and a positive integer if the second one should come before the second one.
+This function gets two rows and has to return a negative integer if the first one should come before the second one, zero if they are equal and a positive integer if the second one should come before the first one.
 
 .. code-block:: python
 


### PR DESCRIPTION
Punctuation, spelling, grammar etc.

This addresses some things I noticed when translating the text. Feel free to drop parts if I have misunderstood some point:

* Remove doubled space, add missing period, some typo fixes.
* Change order of two methods in button_widgets so they have the same order as their float/integer description in the same sentence.
* Change an "i.e" to "e.g" in layout.txt. It looks to me that the example not is the only possibility, and in that case e.g is more suitable.
* In objects.txt it looks like there is a "thawed" that should be "frozen".