### PR TITLE
Use python3 style super consistently

### DIFF
--- a/examples/button_example.py
+++ b/examples/button_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class ButtonWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Button Demo")
+        super().__init__(title="Button Demo")
         self.set_border_width(10)
 
         hbox = Gtk.Box(spacing=6)

--- a/examples/cellrendereraccel_example.py
+++ b/examples/cellrendereraccel_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class CellRendererAccelWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="CellRendererAccel Example")
+        super().__init__(title="CellRendererAccel Example")
 
         self.set_default_size(200, 200)
 

--- a/examples/cellrenderercombo_example.py
+++ b/examples/cellrenderercombo_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class CellRendererComboWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="CellRendererCombo Example")
+        super().__init__(title="CellRendererCombo Example")
 
         self.set_default_size(200, 200)
 

--- a/examples/cellrendererpixbuf_example.py
+++ b/examples/cellrendererpixbuf_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class CellRendererPixbufWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="CellRendererPixbuf Example")
+        super().__init__(title="CellRendererPixbuf Example")
 
         self.set_default_size(200, 200)
 

--- a/examples/cellrendererprogress_example.py
+++ b/examples/cellrendererprogress_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk, GLib
 
 class CellRendererProgressWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="CellRendererProgress Example")
+        super().__init__(title="CellRendererProgress Example")
 
         self.set_default_size(200, 200)
 

--- a/examples/cellrendererspin_example.py
+++ b/examples/cellrendererspin_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class CellRendererSpinWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="CellRendererSpin Example")
+        super().__init__(title="CellRendererSpin Example")
 
         self.set_default_size(200, 200)
 

--- a/examples/cellrenderertext_example.py
+++ b/examples/cellrenderertext_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class CellRendererTextWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="CellRendererText Example")
+        super().__init__(title="CellRendererText Example")
 
         self.set_default_size(200, 200)
 

--- a/examples/cellrenderertoggle_example.py
+++ b/examples/cellrenderertoggle_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class CellRendererToggleWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="CellRendererToggle Example")
+        super().__init__(title="CellRendererToggle Example")
 
         self.set_default_size(200, 200)
 

--- a/examples/checkbutton_example.py
+++ b/examples/checkbutton_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class CheckButtonWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="CheckButton Demo")
+        super().__init__(title="CheckButton Demo")
         self.set_border_width(10)
 
         hbox = Gtk.Box(spacing=6)

--- a/examples/clipboard_example.py
+++ b/examples/clipboard_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk, Gdk
 
 class ClipboardWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Clipboard Example")
+        super().__init__(title="Clipboard Example")
 
         grid = Gtk.Grid()
 

--- a/examples/combobox_example.py
+++ b/examples/combobox_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class ComboBoxWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="ComboBox Example")
+        super().__init__(title="ComboBox Example")
 
         self.set_border_width(10)
 

--- a/examples/dialog_example.py
+++ b/examples/dialog_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class DialogExample(Gtk.Dialog):
     def __init__(self, parent):
-        Gtk.Dialog.__init__(self, title="My Dialog", transient_for=parent, flags=0)
+        super().__init__(title="My Dialog", transient_for=parent, flags=0)
         self.add_buttons(
             Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OK, Gtk.ResponseType.OK
         )

--- a/examples/drag_and_drop_example.py
+++ b/examples/drag_and_drop_example.py
@@ -11,7 +11,7 @@ DRAG_ACTION = Gdk.DragAction.COPY
 
 class DragDropWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Drag and Drop Demo")
+        super().__init__(title="Drag and Drop Demo")
 
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
         self.add(vbox)

--- a/examples/entry_example.py
+++ b/examples/entry_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk, GLib
 
 class EntryWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Entry Demo")
+        super().__init__(title="Entry Demo")
         self.set_size_request(200, 100)
 
         self.timeout_id = None

--- a/examples/expander_example.py
+++ b/examples/expander_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class ExpanderExample(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Expander Demo")
+        super().__init__(title="Expander Demo")
 
         self.set_size_request(350, 100)
 

--- a/examples/extended_example.py
+++ b/examples/extended_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class MyWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Hello World")
+        super().__init__(title="Hello World")
 
         self.button = Gtk.Button(label="Click Here")
         self.button.connect("clicked", self.on_button_clicked)

--- a/examples/filechooserdialog_example.py
+++ b/examples/filechooserdialog_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class FileChooserWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="FileChooser Example")
+        super().__init__(title="FileChooser Example")
 
         box = Gtk.Box(spacing=6)
         self.add(box)

--- a/examples/iconview_example.py
+++ b/examples/iconview_example.py
@@ -9,7 +9,7 @@ icons = ["edit-cut", "edit-paste", "edit-copy"]
 
 class IconViewWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self)
+        super().__init__()
         self.set_default_size(200, 200)
 
         liststore = Gtk.ListStore(Pixbuf, str)

--- a/examples/label_example.py
+++ b/examples/label_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class LabelWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Label Example")
+        super().__init__(title="Label Example")
 
         hbox = Gtk.Box(spacing=10)
         hbox.set_homogeneous(False)

--- a/examples/layout_box_example.py
+++ b/examples/layout_box_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class MyWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Hello World")
+        super().__init__(title="Hello World")
 
         self.box = Gtk.Box(spacing=6)
         self.add(self.box)

--- a/examples/layout_flowbox_example.py
+++ b/examples/layout_flowbox_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk, Gdk
 
 class FlowBoxWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="FlowBox Demo")
+        super().__init__(title="FlowBox Demo")
         self.set_border_width(10)
         self.set_default_size(300, 250)
 

--- a/examples/layout_grid_example.py
+++ b/examples/layout_grid_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class GridWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Grid Example")
+        sper().__init__(title="Grid Example")
 
         grid = Gtk.Grid()
         self.add(grid)

--- a/examples/layout_headerbar_example.py
+++ b/examples/layout_headerbar_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk, Gio
 
 class HeaderBarWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="HeaderBar Demo")
+        super().__init__(title="HeaderBar Demo")
         self.set_border_width(10)
         self.set_default_size(400, 200)
 

--- a/examples/layout_listbox_example.py
+++ b/examples/layout_listbox_example.py
@@ -6,14 +6,14 @@ from gi.repository import Gtk
 
 class ListBoxRowWithData(Gtk.ListBoxRow):
     def __init__(self, data):
-        super(Gtk.ListBoxRow, self).__init__()
+        super().__init__()
         self.data = data
         self.add(Gtk.Label(label=data))
 
 
 class ListBoxWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="ListBox Demo")
+        super().__init__(title="ListBox Demo")
         self.set_border_width(10)
 
         box_outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)

--- a/examples/layout_stack_example.py
+++ b/examples/layout_stack_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class StackWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Stack Demo")
+        super().__init__(title="Stack Demo")
         self.set_border_width(10)
 
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)

--- a/examples/layout_table_example.py
+++ b/examples/layout_table_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class TableWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Table Example")
+        super().__init__(title="Table Example")
 
         table = Gtk.Table(n_rows=3, n_columns=3, homogeneous=True)
         self.add(table)

--- a/examples/linkbutton_example.py
+++ b/examples/linkbutton_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class LinkButtonWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="LinkButton Demo")
+        super().__init__(title="LinkButton Demo")
         self.set_border_width(10)
 
         button = Gtk.LinkButton.new_with_label(

--- a/examples/menu_example.py
+++ b/examples/menu_example.py
@@ -42,7 +42,7 @@ UI_INFO = """
 
 class MenuExampleWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Menu Example")
+        self().__init__(title="Menu Example")
 
         self.set_default_size(200, 200)
 

--- a/examples/messagedialog_example.py
+++ b/examples/messagedialog_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class MessageDialogWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="MessageDialog Example")
+        super().__init__(title="MessageDialog Example")
 
         box = Gtk.Box(spacing=6)
         self.add(box)

--- a/examples/notebook_plain_example.py
+++ b/examples/notebook_plain_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class MyWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Simple Notebook Example")
+        super().__init__(title="Simple Notebook Example")
         self.set_border_width(3)
 
         self.notebook = Gtk.Notebook()

--- a/examples/popover_example.py
+++ b/examples/popover_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class PopoverWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Popover Demo")
+        super().__init__(title="Popover Demo")
         self.set_border_width(10)
         self.set_default_size(300, 200)
 

--- a/examples/progressbar_example.py
+++ b/examples/progressbar_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk, GLib
 
 class ProgressBarWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="ProgressBar Demo")
+        super().__init__(title="ProgressBar Demo")
         self.set_border_width(10)
 
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)

--- a/examples/radiobutton_example.py
+++ b/examples/radiobutton_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class RadioButtonWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="RadioButton Demo")
+        super().__init__(title="RadioButton Demo")
         self.set_border_width(10)
 
         hbox = Gtk.Box(spacing=6)

--- a/examples/spinbutton_example.py
+++ b/examples/spinbutton_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class SpinButtonWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="SpinButton Demo")
+        super().__init__(title="SpinButton Demo")
         self.set_border_width(10)
 
         hbox = Gtk.Box(spacing=6)

--- a/examples/spinner_example.py
+++ b/examples/spinner_example.py
@@ -7,7 +7,7 @@ from gi.repository import Gtk
 class SpinnerAnimation(Gtk.Window):
     def __init__(self):
 
-        Gtk.Window.__init__(self, title="Spinner")
+        super().__init__(title="Spinner")
         self.set_border_width(3)
         self.connect("destroy", Gtk.main_quit)
 

--- a/examples/spinner_ext_example.py
+++ b/examples/spinner_ext_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk, GLib
 
 class SpinnerWindow(Gtk.Window):
     def __init__(self, *args, **kwargs):
-        Gtk.Window.__init__(self, title="Spinner Demo")
+        super().__init__(title="Spinner Demo")
         self.set_border_width(10)
 
         mainBox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)

--- a/examples/switch_example.py
+++ b/examples/switch_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class SwitcherWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Switch Demo")
+        super().__init__(title="Switch Demo")
         self.set_border_width(10)
 
         hbox = Gtk.Box(spacing=6)

--- a/examples/textview_example.py
+++ b/examples/textview_example.py
@@ -6,9 +6,7 @@ from gi.repository import Gtk, Pango
 
 class SearchDialog(Gtk.Dialog):
     def __init__(self, parent):
-        Gtk.Dialog.__init__(
-            self, title="Search", transient_for=parent, modal=True,
-        )
+        super().__init__(title="Search", transient_for=parent, modal=True)
         self.add_buttons(
             Gtk.STOCK_FIND,
             Gtk.ResponseType.OK,

--- a/examples/togglebutton_example.py
+++ b/examples/togglebutton_example.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 
 class ToggleButtonWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="ToggleButton Demo")
+        super().__init__(title="ToggleButton Demo")
         self.set_border_width(10)
 
         hbox = Gtk.Box(spacing=6)

--- a/examples/treeview_filter_example.py
+++ b/examples/treeview_filter_example.py
@@ -21,7 +21,7 @@ software_list = [
 
 class TreeViewFilterWindow(Gtk.Window):
     def __init__(self):
-        Gtk.Window.__init__(self, title="Treeview Filter Demo")
+        super().__init__(title="Treeview Filter Demo")
         self.set_border_width(10)
 
         # Setting up the self.grid in which the elements are to be positionned


### PR DESCRIPTION
Static syntax checker flagged layout_listbox_example.py at:
    super(Gtk.ListBoxRow, self).__init__()
as:
    bad-super-call: Bad first argument 'ListBoxRow' given to super()

This got me to check recent python3 situation.
    https://docs.python.org/3.9/library/functions.html#super
    https://rhettinger.wordpress.com/2011/05/26/super-considered-super/

After reading this and updating this part of code, I also realized all
subclass of Gtk.Window except one in popover_advanced_example.py were
not using super() but calling it directly in the subclass's __init__.
Not so nice.

I decided to fix them all for cleaner consistency.

Signed-off-by: Osamu Aoki <osamu@debian.org>