### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/spinner_ext_example.py
+++ b/examples/spinner_ext_example.py
@@ -67,7 +67,7 @@ class SpinnerWindow(Gtk.Window):
         """ Start the timer. """
         self.buttonStart.set_sensitive(False)
         self.buttonStop.set_sensitive(True)
-        # time out will check every 250 miliseconds (1/4 of a second)
+        # time out will check every 250 milliseconds (1/4 of a second)
         self.counter = 4 * int(self.entry.get_text())
         self.label.set_label("Remaining: " + str(int(self.counter / 4)))
         self.spinner.start()

--- a/examples/treeview_filter_example.py
+++ b/examples/treeview_filter_example.py
@@ -24,7 +24,7 @@ class TreeViewFilterWindow(Gtk.Window):
         super().__init__(title="Treeview Filter Demo")
         self.set_border_width(10)
 
-        # Setting up the self.grid in which the elements are to be positionned
+        # Setting up the self.grid in which the elements are to be positioned
         self.grid = Gtk.Grid()
         self.grid.set_column_homogeneous(True)
         self.grid.set_row_homogeneous(True)


### PR DESCRIPTION
There are small typos in:
- examples/spinner_ext_example.py
- examples/treeview_filter_example.py

Fixes:
- Should read `positioned` rather than `positionned`.
- Should read `milliseconds` rather than `miliseconds`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md