### PR TITLE
Updated 404 link

### DIFF
--- a/source/install.txt
+++ b/source/install.txt
@@ -59,6 +59,6 @@ To start a shell with the same environment as used by JHBuild, run::
 
 .. _PyGObject: https://wiki.gnome.org/action/show/Projects/PyGObject
 .. _JHBuild: https://wiki.gnome.org/action/show/Projects/Jhbuild
-.. _JHBuild manual: https://developer.gnome.org/jhbuild/unstable/
+.. _JHBuild manual: https://gnome.pages.gitlab.gnome.org/jhbuild/index.html
 
 .. [#] https://download.gnome.org/teams/releng/


### PR DESCRIPTION
The JHBuild manual link redirected to a 404 page. Hopefully this is the intended destination :)