### PR TITLE
Update versions in requirements.txt and Python in Dockerfile

### DIFF
--- a/.github/actions/sphinx-build-all/Dockerfile
+++ b/.github/actions/sphinx-build-all/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.12-slim
 
 RUN apt-get update \
  && apt-get install -y \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,5 @@
-Sphinx <7.3.7
-sphinx-autobuild
-sphinxcontrib-applehelp <1.0.8
-sphinxcontrib-devhelp <1.0.6
-sphinxcontrib-htmlhelp <2.0.5
-sphinxcontrib-qthelp <1.0.7
-sphinxcontrib-serializinghtml <1.1.10
-sphinx-rtd-theme <2
-sphinx-intl
-Jinja2 <3.1.3
+Sphinx ~=7.3.7
+sphinx-autobuild ~= 2024.4.16
+sphinx-rtd-theme ~=2.0.0
+sphinx-intl ~=2.2.0
+Jinja2 ~=3.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Sphinx ~=7.3.7
 sphinx-autobuild ~= 2024.4.16
 sphinx-rtd-theme ~=2.0.0
 sphinx-intl ~=2.2.0
-Jinja2 ~=3.25.1
+Jinja2 ~=3.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-Sphinx<4
+Sphinx <7.3.7
 sphinx-autobuild
-sphinxcontrib-applehelp <1.0.5
-sphinxcontrib-devhelp <1.0.3
-sphinxcontrib-htmlhelp <2.0.2
-sphinxcontrib-qthelp <1.0.4
-sphinxcontrib-serializinghtml <1.1.6
+sphinxcontrib-applehelp <1.0.8
+sphinxcontrib-devhelp <1.0.6
+sphinxcontrib-htmlhelp <2.0.5
+sphinxcontrib-qthelp <1.0.7
+sphinxcontrib-serializinghtml <1.1.10
 sphinx-rtd-theme <2
 sphinx-intl
-Jinja2 <3.1.0
+Jinja2 <3.1.3


### PR DESCRIPTION
Sphinx <4 is not compatible with Python 3.10+, so updating requirements.txt is needed. Since we're here, I updated the python image used in Dockerfile.