### PR TITLE
Fixed GNOME wiki for installing dependencies

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,7 @@
+version = 1
+
+[[analyzers]]
+name = "python"
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"

--- a/source/install.txt
+++ b/source/install.txt
@@ -44,7 +44,7 @@ by running::
 
 It will print any applications and libraries that are currently missing on your
 system but required for building. You should install those using your distribution's
-package repository. A list of `package names <https://wiki.gnome.org/action/show/Projects/Jhbuild/Dependencies>`_
+package repository. A list of `package names <https://wiki.gnome.org/Projects/Jhbuild/Introduction/#Setting_up_JHBuild>`_
 for different distributions is maintained on the GNOME wiki.
 Run the command above again to ensure the required tools are present.
 


### PR DESCRIPTION
In Chapter 1 1.3 Installing from source, it says to install missing packages and suggests a link to the packages names. It is from a GNOME page, but it seems to don't load as this image shows. 

![image](https://github.com/user-attachments/assets/27a579ae-9744-4a9b-850d-5befb00ecc8c)

I think the right link is this from GNOME wiki https://wiki.gnome.org/Projects/Jhbuild/Introduction/#Setting_up_JHBuild .

I recently changed some configurations in my private network, so maybe that's why I can't access, but if someone else can, let me know.